### PR TITLE
add endpoints to get student/instr courses from DB

### DIFF
--- a/pages/api/find-instr-courses.tsx
+++ b/pages/api/find-instr-courses.tsx
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getDB } from "../../src/database";
+
+// API endpoint to return list of course IDs
+// taught by an instructor (given their emplid)
+// Usage: /api/find-instr-courses?emplid=EMPLID
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const emplid = req.query.emplid; // instructor ID
+  const isInstructor = await checkValidId(emplid as string);
+
+  if (isInstructor) {
+    const dbCourses = (await getDB()).collection("courses");
+    return dbCourses
+      .find({ instructors: emplid }, { projection: { _id: 0, course_id: 1 } })
+      .toArray()
+      .then((allCourses) => {
+        const courseIds = allCourses.map((course) => {
+          return course["course_id"];
+        });
+        return res.status(200).json({ course_ids: courseIds });
+      });
+  } else {
+    return res
+      .status(404)
+      .json({ message: `${emplid} is not a valid instructor ID` });
+  }
+}
+
+// Check if emplid is valid instructor
+async function checkValidId(emplid: string) {
+  const dbUsers = (await getDB()).collection("users");
+  return dbUsers
+    .find({ instructorid: emplid })
+    .toArray()
+    .then((instr) => {
+      return instr.length !== 0;
+    });
+}

--- a/pages/api/get-user-courses.tsx
+++ b/pages/api/get-user-courses.tsx
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getDB } from "../../src/database";
+
+// API endpoint to return list of stored courses
+// being taught by an instructor / taken by a student
+// (given their netid)
+// Usage: /api/get-courses?netid=NETID
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const netid = req.query.netid;
+  const dbUsers = (await getDB()).collection("users");
+  return dbUsers
+    .findOne(
+      { netid: netid },
+      {
+        projection: {
+          _id: 0,
+          instructor_courses: 1,
+          student_courses: 1,
+          person_type: 1,
+        },
+      }
+    )
+    .then((user) => {
+      // if given netid is not valid
+      if (user == null) {
+        return res.status(404).json(`user ${netid} not found in DB`);
+      }
+      if (user["person_type"] === "instructor") {
+        return res.status(200).json({ course_ids: user["instructor_courses"] });
+      } else {
+        return res.status(200).json({ course_ids: user["student_courses"] });
+      }
+    });
+}


### PR DESCRIPTION
* `/api/find-instr-courses?emplid=EMPLID` to return list of course IDs for courses this instructor teachers. `emplid` is the numerical ID for an instructor. This endpoint should be used when initially constructing a document for an instructor.
* `/api/get-user-courses?netid=NETID` to return list of course IDs for courses an instructor teachers / student takes. This assumes the instructor / student courses have already been populated in the DB.

Includes validation checks that given `EMPLID` and `NETID` are valid users.